### PR TITLE
Automate packaging on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,26 @@
+name: Package and Release
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Package addon
+        run: |
+          ADDON=Tracky
+          mkdir -p $ADDON
+          cp *.lua *.toc *.xml README.md LICENSE $ADDON/
+          zip -r ${ADDON}-${GITHUB_REF_NAME}.zip $ADDON
+
+      - name: Upload release asset
+        uses: softprops/action-gh-release@v1
+        with:
+          files: Tracky-${{ github.ref_name }}.zip


### PR DESCRIPTION
## Summary
- package addon into zip whenever a GitHub release is published
- upload generated zip as a release asset

## Testing
- `luac -p Tracky.lua TrackyItems.lua` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68c6df7cdd40832b89e5366b6e1d4f69