### PR TITLE
Fix overlapping input fields in Tracky config UI

### DIFF
--- a/Tracky.lua
+++ b/Tracky.lua
@@ -192,6 +192,16 @@ local content = CreateFrame("Frame", nil, scrollFrame)
 content:SetSize(400, 1) -- Breite fix, Höhe dynamisch
 scrollFrame:SetScrollChild(content)
 
+-- Sicherstellen, dass die Eingabefelder vor dem ScrollFrame liegen
+local overlayFixLevel = scrollFrame:GetFrameLevel() + 1
+searchBox:SetFrameLevel(overlayFixLevel)
+recipeBox:SetFrameLevel(overlayFixLevel)
+recipeQty:SetFrameLevel(overlayFixLevel)
+recipeQtyLbl:SetFrameLevel(overlayFixLevel)
+recipeAddBtn:SetFrameLevel(overlayFixLevel)
+addBox:SetFrameLevel(overlayFixLevel)
+addBtn:SetFrameLevel(overlayFixLevel)
+
 config.list = {}
 
 -- passt die ScrollFrame-Größe bei Fenster-Resize an


### PR DESCRIPTION
## Summary
- Ensure item add and quantity fields stay above the scroll frame to prevent occlusion

## Testing
- `luac -p Tracky.lua TrackyItems.lua` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c6f56fc4d4832bac052279e1a217c5